### PR TITLE
Avoid logging to root logger

### DIFF
--- a/HardwareMonitor/Util.py
+++ b/HardwareMonitor/Util.py
@@ -6,6 +6,7 @@ import HardwareMonitor
 from HardwareMonitor.Hardware import Computer, IVisitor, IComputer, IHardware, IParameter, ISensor, HardwareType, SensorType
 from System.Collections.Generic import IList, IDictionary
 
+logger = logging.getLogger("PyHardwareMonitor")
 
 # ------------------------------------------------------------------------------
 def _get_name_to_type(obj):
@@ -81,7 +82,7 @@ def UpdateHardwareSafe(hardware: IHardware):
         hardware.Update()
     except:
         if hardware.Identifier not in _UPDATE_WARNING_CACHE:
-            logging.warning(f"Unable to update HardwareMonitor sensors for {hardware.Identifier} ('{hardware.Name}')")
+            logger.warning(f"Unable to update HardwareMonitor sensors for {hardware.Identifier} ('{hardware.Name}')")
             _UPDATE_WARNING_CACHE.add(hardware.Identifier)
 
 

--- a/HardwareMonitor/__init__.py
+++ b/HardwareMonitor/__init__.py
@@ -10,7 +10,7 @@ logger = logging.getLogger("PyHardwareMonitor")
 
 
 if not ctypes.windll.shell32.IsUserAnAdmin():
-    logger.warning("Admin privileges are required for 'HarwareMonitor' to work properly")
+    logger.warning("Admin privileges are required for 'HardwareMonitor' to work properly")
 
 ASSEMBLY_NAME = "LibreHardwareMonitor"
 

--- a/HardwareMonitor/__init__.py
+++ b/HardwareMonitor/__init__.py
@@ -6,11 +6,11 @@ import logging
 from   pathlib import Path
 
 
-logging.basicConfig(format='%(levelname)s: %(message)s')
+logger = logging.getLogger("PyHardwareMonitor")
 
 
 if not ctypes.windll.shell32.IsUserAnAdmin():
-    logging.warning("Admin privileges are required for 'HarwareMonitor' to work properly")
+    logger.warning("Admin privileges are required for 'HarwareMonitor' to work properly")
 
 ASSEMBLY_NAME = "LibreHardwareMonitor"
 


### PR DESCRIPTION
This PR removes the use of the root logger from the `logging` module and introduces instead a specific logger named as the package itself. The reason is that PyHardwareMonitor is a library, and logging configuration is typically a prerogative of the application code, as explained [here](https://docs.python.org/3/howto/logging.html#configuring-logging-for-a-library) and [here](https://stackoverflow.com/questions/27016870/how-should-logging-be-used-in-a-python-package). 

Using the root logger in library code is especially problematic in `__init__` modules, as they are typically called very early by the application code, possibly before the configuration of the logger. This means that the configuration (even if it was the default one) of the library, is likely to override the one of the application.

The logging formatting is also removed by this PR, as it is discouraged to add handlers and formatters in library code, even if a specific logger is used. Anyway, it is relatively easy to add it with something like:
```python
handler = logging.StreamHandler()
formatter = logging.Formatter(fmt='%(levelname)s: %(message)s')
handler.setFormatter(formatter)
logger.addHandler(handler)
```
just after the definition of the logger, currently in line 9 of the main `__init__.py`.